### PR TITLE
Fix compiler detection when using --without-{crypt,crypto,ssl}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_CONFIG_HEADER(config.h)
 AC_CONFIG_MACRO_DIR([m4])
 
+AC_PROG_CC
 AC_PROG_SED
 
 # some OS's need both -lssl and -lcrypto on link line:


### PR DESCRIPTION
As the author of #13 honestly admitted, moving around parts of `configure.ac` to fix its horrors is not the best solution.  Specifically, the change introduced by #13 causes compilation to fail when `--without-crypto` and/or `--without-ssl` is used.

The root problem with `configure.ac` is that if the combination of `configure` switches used does not cause at least one branch with `AC_CHECK_LIB` to be evaluated then the C compiler is never detected.

The simplest way to fix this appears to be to explicitly look for a working C compiler before doing anything else and this is what this pull request attempts.

**DISCLAIMER:** I am no Autotools expert.  This just happened to work for me.