### PR TITLE
Fix building against LibreSSL 2.3.0+

### DIFF
--- a/src/enc.h
+++ b/src/enc.h
@@ -454,8 +454,10 @@ extern void enc_do(char *ciph, char *keyfile, char *lport, char *rhp) {
 		p++;
 		if (strstr(p, "md5+") == p) {
 			Digest = EVP_md5();        p += strlen("md5+");
+#ifndef OPENSSL_NO_SHA0
 		} else if (strstr(p, "sha+") == p) {
 			Digest = EVP_sha();        p += strlen("sha+");
+#endif
 		} else if (strstr(p, "sha1+") == p) {
 			Digest = EVP_sha1();       p += strlen("sha1+");
 		} else if (strstr(p, "ripe+") == p) {


### PR DESCRIPTION
LibreSSL 2.3.0 removed support for SHA-0, so this pull request suggests a workaround following [official LibreSSL guidelines](https://wiki.freebsd.org/LibreSSL/PatchingPorts#SHA-0) which fixes compilation against LibreSSL 2.3.0 or newer.