### PR TITLE
Openssl 1.1.0 support

### DIFF
--- a/README
+++ b/README
@@ -872,6 +872,14 @@ make
    place. As of x11vnc 0.9.4 there is also the --with-ssl=DIR configure
    option.
 
+   Note that from OpenSSL 1.1.0 on SSLv2 support has been dropped and
+   SSLv3 deactivated at build time per default. This means that unless
+   explicitly enabled, OpenSSL builds only support TLS (any version).
+   Since there is a reason for dropping SSLv3 (heard of POODLE?), most
+   distributions do not enable it for their OpenSSL binary. In summary
+   this means compiling x11vnc against OpenSSL 1.1.0 or newer is no
+   problem, but using encryption will require a viewer with TLS support.
+
    On Solaris using static archives libssl.a and libcrypto.a instead of
    .so shared libraries (e.g. from www.sunfreeware.com), we found we
    needed to also set LDFLAGS as follows to get the configure to work:
@@ -4219,6 +4227,14 @@ connect = 5900
    VeNCrypt, on the other hand, switches to SSL/TLS early in the VNC
    protocol handshake. x11vnc 0.9.6 supports both simultaneously when
    -ssl is active.
+
+   Note: With the advent of OpenSSL 1.1.0, SSLv2 is dropped and SSLv3
+   deactivated per default. A couple broken ciphers have also gone, most
+   importantly though is that clients trying to connect to x11vnc will
+   now have to support TLS if encryption is to be used. You can of
+   course always cook up your own build and run time OpenSSL 1.1.x if
+   SSLv3 is absolutely required, but it isn't wise from a security point
+   of view.
 
 
    SSL VNC Viewers:. Viewer-side will need to use SSL as well. See the

--- a/configure.ac
+++ b/configure.ac
@@ -60,12 +60,11 @@ AC_SUBST(CRYPT_LIBS)
 AH_TEMPLATE(HAVE_X509_PRINT_EX_FP, [open ssl X509_print_ex_fp available])
 if test "x$with_ssl" != "xno"; then
 	if test "x$HAVE_LIBCRYPTO" = "xtrue"; then
-		AC_CHECK_LIB(ssl, SSL_library_init,
+		PKG_CHECK_MODULES(OPENSSL, [openssl >= 1.0.0],
 			SSL_LIBS="-lssl -lcrypto"
-			[AC_DEFINE(HAVE_LIBSSL) HAVE_LIBSSL="true"], ,
-			-lcrypto)
+			[AC_DEFINE(HAVE_LIBSSL) HAVE_LIBSSL="true"], ,)
 	else
-		AC_CHECK_LIB(ssl, SSL_library_init,
+		PKG_CHECK_MODULES(OPENSSL, [openssl >= 1.0.0],
 			SSL_LIBS="-lssl"
 			[AC_DEFINE(HAVE_LIBSSL) HAVE_LIBSSL="true"], ,)
 	fi


### PR DESCRIPTION
These patches add support for building against the openssl 1.1.0 API. Changes to the API compared to the 1.0.2 series are significant; a lot of structures were made opaque, several functions were renamed. The first patch fixes configure detection for openssl (one of those function renames), the second patch implements the API changes as close to the original sources as it could get. That meant a lot of preprocessor conditionals, but I'm confident things still work as they should. The code builds against both openssl 1.1.0c (armv7l cross-compiled) and 1.0.2j (x86_64 host).

Let me know if something's off (especially configure.ac), I'm happy to make changes when required.