### PR TITLE
Travis, OS X & OpenSSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ compiler:
 # install all vnc-related dependencies
 before_install:
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get build-dep x11vnc; fi'
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CFLAGS="-I/usr/local/opt/openssl/include $CFLAGS" LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"; wget https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.10.tar.gz; tar xzf LibVNCServer-0.9.10.tar.gz; cd libvncserver-LibVNCServer-0.9.10; autoreconf -fi; ./configure; make; sudo make install; cd ..; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CFLAGS="-I/usr/local/opt/openssl/include $CFLAGS" LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS" PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.10.tar.gz; tar xzf LibVNCServer-0.9.10.tar.gz; cd libvncserver-LibVNCServer-0.9.10; autoreconf -fi; ./configure; make; sudo make install; cd ..; fi'
 
 
 # before build script, run autoreconf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ compiler:
 # install all vnc-related dependencies
 before_install:
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get build-dep x11vnc; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall openssl && brew install openssl --universal --without-test; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CFLAGS="-I/usr/local/opt/openssl/include $CFLAGS" LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS" PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.10.tar.gz; tar xzf LibVNCServer-0.9.10.tar.gz; cd libvncserver-LibVNCServer-0.9.10; autoreconf -fi; ./configure; make; sudo make install; cd ..; fi'
 


### PR DESCRIPTION
I took a shot at those pesky OS X builds with their outdated openssl 0.98zh package. For the builds itself a `pkgconfig` path addition was enough. However, 0.98 is outdated and unsupported, so an upgrade to 1.0.2j is done before trying to build both libvncserver and x11vnc (which also happens to fix builds including #30).