### PR TITLE
Fix -localhost option for IPv6

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -136,6 +136,7 @@ int started_as_root = 0;
 int host_lookup = 1;
 char *unix_sock = NULL;
 int unix_sock_fd = -1;
+int got_localhost = 0;
 #if X11VNC_LISTEN6
 int ipv6_listen = 1;		/* -6 / -no6 */
 int got_ipv6_listen = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -117,6 +117,7 @@ extern int started_as_root;
 extern int host_lookup;
 extern char *unix_sock;
 extern int unix_sock_fd;
+extern int got_localhost;
 extern int ipv6_listen;
 extern int got_ipv6_listen;
 extern int ipv6_listen_fd;

--- a/src/screen.c
+++ b/src/screen.c
@@ -3704,6 +3704,10 @@ void initialize_screen(int *argc, char **argv, XImage *fb) {
 		defer_update = screen->deferUpdateTime;
 	}
 
+	if (got_localhost) {
+		screen->listen6Interface = "::1";
+	}
+
 	if (noipv4 || getenv("IPV4_FAILS")) {
 		rfbBool ap = screen->autoPort;
 		int port = screen->port;

--- a/src/x11vnc.c
+++ b/src/x11vnc.c
@@ -2047,7 +2047,7 @@ int main(int argc, char* argv[]) {
 	char *gui_str = NULL;
 	int got_gui_pw = 0;
 	int pw_loc = -1, got_passwd = 0, got_rfbauth = 0, nopw = NOPW;
-	int got_viewpasswd = 0, got_localhost = 0, got_passwdfile = 0;
+	int got_viewpasswd = 0, got_passwdfile = 0;
 	int vpw_loc = -1;
 	int dt = 0, bg = 0;
 	int got_rfbwait = 0;


### PR DESCRIPTION
Fix Debian Bug #672435 [1].

1. Turn `got_localhost` flag (which indicates the presence of "-localhost"
   option) into a global variable.
2. Prior to initializing (`rfbInitServer`) the server, check the flag and
   set `listen6Interface` to "::1" to listen on IPv6 loopback interface.

An alternative approach would be to pass "-listenv6 localhost" option to
LibVNCServer via `rfbGetScreen`, see [2], [3], or set `listen_str6` and
implement "-localhost" option together with "-listen6 localhost" [4].

This change, however, is intended to be a bugfix, and aforementioned
alternatives could be considered later when refactoring [2].

References:
1. [x11vnc: Option -localhost seems to fail to restrict ipv6 access](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672435)
2. https://github.com/LibVNC/x11vnc/blob/0.9.14/src/x11vnc.c#L4949
3. https://github.com/LibVNC/libvncserver/blob/LibVNCServer-0.9.11/libvncserver/cargs.c#L56
4. https://github.com/LibVNC/x11vnc/blob/0.9.14/src/x11vnc.c#L2542