### PR TITLE
Travis: use Ubuntu Trusty (14.04) for building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+dist: trusty
+
 os:
   - linux
   - osx


### PR DESCRIPTION
Using Trusty instead of Precise makes libvncserver 0.9.9 available and
enables IPv6 support at build time. Also fixes the travis issue at #33.