### PR TITLE
Fix some memleaks

### DIFF
--- a/src/enc.h
+++ b/src/enc.h
@@ -2092,7 +2092,7 @@ static void doloop (int argc, char *argv[]) {
 			}
 		}
 
-		putenv("ULTRAVNC_DSM_HELPER_LOOP_SET=1");
+		setenv("ULTRAVNC_DSM_HELPER_LOOP_SET", "1", 1);
 		if (ms == 1) {
 			ms = 500;
 		}

--- a/src/remote.c
+++ b/src/remote.c
@@ -1772,10 +1772,11 @@ char *process_remote_cmd(char *cmd, int stringonly) {
 		}
 		rfbLog("remote_cmd: enable -avahi mDNS mode.\n");
 		if (!avahi) {
+			char *host = this_host();
 			avahi = 1;
 			avahi_initialise();
-			avahi_advertise(vnc_desktop_name, this_host(),
-			    screen->port);
+			avahi_advertise(vnc_desktop_name, host, screen->port);
+			free(host);
 		}
 		goto done;
 	}
@@ -5833,8 +5834,10 @@ char *process_remote_cmd(char *cmd, int stringonly) {
 				d = DisplayString(dpy);
 				if (! d) d = "unknown";
 				if (*d == ':') {
+					char *host = this_host();
 					snprintf(buf, bufn, "aro=%s:%s%s", p,
-					    this_host(), d);
+					    host, d);
+					free(host);
 				} else {
 					snprintf(buf, bufn, "aro=%s:%s", p, d);
 				}

--- a/src/screen.c
+++ b/src/screen.c
@@ -3793,6 +3793,7 @@ void announce(int lport, int ssl, char *iface) {
 	}
 
 	if (iface != NULL && *iface != '\0' && strcmp(iface, "any")) {
+		free(host);
 		host = iface;
 	}
 	if (host != NULL) {
@@ -3832,12 +3833,16 @@ void announce(int lport, int ssl, char *iface) {
 			rfbLog("possible alias:    %s::%d\n",
 			    host, lport);
 		}
+
+		if (host != iface)
+			free(host);
 	}
 }
 
 static void announce_http(int lport, int ssl, char *iface, char *extra) {
-	
+	/* Result of this_host is allocated memory and must be freed. */
 	char *host = this_host();
+	char *phost = host;
 	char *jvu;
 	int http = 0;
 
@@ -3855,16 +3860,17 @@ static void announce_http(int lport, int ssl, char *iface, char *extra) {
 	}
 
 	if (iface != NULL && *iface != '\0' && strcmp(iface, "any")) {
-		host = iface;
+		phost = iface;
 	}
 	if (http && getenv("X11VNC_HTTP_LISTEN_LOCALHOST")) {
-		host = "localhost";
+		phost = "localhost";
 	}
-	if (host != NULL) {
+	if (phost != NULL) {
 		if (! inetd) {
-			fprintf(stderr, "%s://%s:%d/%s\n", jvu, host, lport, extra);
+			fprintf(stderr, "%s://%s:%d/%s\n", jvu, phost, lport, extra);
 		}
 	}
+	free(host);
 }
 
 void do_announce_http(void) {
@@ -3941,8 +3947,9 @@ void do_mention_java_urls(void) {
 void set_vnc_desktop_name(void) {
 	sprintf(vnc_desktop_name, "unknown");
 	if (inetd) {
-		sprintf(vnc_desktop_name, "%s/inetd-no-further-clients",
-		    this_host());
+		char *host = this_host();
+		sprintf(vnc_desktop_name, "%s/inetd-no-further-clients", host);
+		free(host);
 	}
 	if (remote_direct) {
 		return;

--- a/src/user.c
+++ b/src/user.c
@@ -1472,11 +1472,13 @@ static void setup_service(void) {
 		fflush(stdout);
 	} else if (!use_openssl && avahi) {
 		char *name = rfb_desktop_name;
+		char *host = this_host();
 		if (!name) {
 			name = use_dpy;
 		}
 		avahi_initialise();
-		avahi_advertise(name, this_host(), screen->port);
+		avahi_advertise(name, host, screen->port);
+		free(host);
 	}
 }
 

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -242,7 +242,6 @@ static void parse_scroll_copyrect_str(char *scr) {
 			scrollcopyrect_left  = l;
 			scrollcopyrect_right = r;
 		}
-		free(str);
 	}
 
 	/* key scrolling timing heuristics. */
@@ -253,7 +252,6 @@ static void parse_scroll_copyrect_str(char *scr) {
 			scr_key_persist = t2;
 			scr_key_bdpush_time = t3;
 		}
-		free(str);
 	}
 
 	/* mouse scrolling timing heuristics. */
@@ -267,8 +265,10 @@ static void parse_scroll_copyrect_str(char *scr) {
 			scr_mouse_pointer_delay = t4;
 			scr_mouse_maxtime = t5;
 		}
-		free(str);
 	}
+
+	for (i = 0; i < 16; i++)
+		free(part[i]);
 }
 
 void parse_scroll_copyrect(void) {
@@ -406,7 +406,6 @@ static void parse_wireframe_str(char *wf) {
 		} else if (sscanf(str, "%lx", &n) == 1) {
 			wireframe_shade = n;	
 		}
-		free(str);
 	}
 
 	/* linewidth: # of pixels wide for the wireframe lines */
@@ -421,7 +420,6 @@ static void parse_wireframe_str(char *wf) {
 				wireframe_lw = LW_MAX; 
 			}
 		}
-		free(str);
 	}
 
 	/* percentage cutoff for opaque move/resize (like WM's) */
@@ -433,7 +431,6 @@ static void parse_wireframe_str(char *wf) {
 		} else {
 			wireframe_frac = ((double) atoi(str))/100.0;
 		}
-		free(str);
 	}
 
 	/*
@@ -448,7 +445,6 @@ static void parse_wireframe_str(char *wf) {
 			wireframe_left  = l;
 			wireframe_right = r;
 		}
-		free(str);
 	}
 
 	/*
@@ -482,8 +478,10 @@ static void parse_wireframe_str(char *wf) {
 			wireframe_t3 = t3;
 			wireframe_t4 = t4;
 		}
-		free(str);
 	}
+
+	for (i = 0; i < 16; i++)
+		free(part[i]);
 }
 
 /*

--- a/src/util.c
+++ b/src/util.c
@@ -32,6 +32,7 @@ so, delete this exception statement from your version.
 
 /* -- util.c -- */
 
+#include <stdlib.h>
 #include "x11vnc.h"
 #include "cleanup.h"
 #include "win_utils.h"
@@ -240,9 +241,8 @@ void set_env(char *name, char *value) {
 	if (! value) {
 		value = "";
 	}
-	str = (char *) malloc(strlen(name) + 1 + strlen(value) + 1);
-	sprintf(str, "%s=%s", name, value);
-	putenv(str);
+
+	setenv(name, value, 1);
 }
 
 char *bitprint(unsigned int st, int nbits) {

--- a/src/util.c
+++ b/src/util.c
@@ -725,12 +725,11 @@ char *choose_title(char *display) {
 			u = "someone";
 		}
 		strcpy(title, u);
-		if (th == NULL && UT.nodename) {
-			th = UT.nodename;
-		}
-		if (th) {
+		if (th || UT.nodename) {
 			strcat(title, "@");
-			strncat(title, th, MAXN - strlen(title));
+			strncat(title, th ? th : UT.nodename,
+				MAXN - strlen(title));
+			free(th);
 		}
 		return title;
 	}
@@ -746,6 +745,7 @@ char *choose_title(char *display) {
 		char *th = this_host();
 		if (th != NULL) {
 			strncpy(title, th, MAXN - strlen(title));
+			free(th);
 		}
 	}
 	strncat(title, display, MAXN - strlen(title));

--- a/src/x11vnc.c
+++ b/src/x11vnc.c
@@ -4326,6 +4326,7 @@ int main(int argc, char* argv[]) {
 			}
 			s = (char *) malloc(strlen(h) + 32);
 			sprintf(s, "%s:%d", h, p);
+			free(h);
 			n = 1;
 			q = logfile;
 			while (1) {

--- a/src/xkb_bell.c
+++ b/src/xkb_bell.c
@@ -54,7 +54,8 @@ void check_bell_event(void);
 void initialize_xkb(void) {
 	int ir, reason;
 	int op, ev, er, maj, min;
-	
+	Display* xkb_disp;
+
 	RAWFB_RET_VOID
 
 	if (xkbcompat) {
@@ -76,14 +77,19 @@ void initialize_xkb(void) {
 		return;
 	}
 
-	if (! XkbOpenDisplay(DisplayString(dpy), &xkb_base_event_type, &ir,
-	    NULL, NULL, &reason) ) {
+	/* XkbOpenDisplay returns a connection, close it to avoid a memleak */
+	xkb_disp = XkbOpenDisplay(DisplayString(dpy), &xkb_base_event_type, &ir,
+		NULL, NULL, &reason);
+
+	if (!xkb_disp) {
 		if (! quiet) {
 			rfbLog("warning: disabling XKEYBOARD. XkbOpenDisplay"
 			    " failed.\n");
 		}
 		xkb_base_event_type = 0;
 		xkb_present = 0;
+	} else {
+		XCloseDisplay(xkb_disp);
 	}
 	xauth_raw(0);
 }


### PR DESCRIPTION
Had a bit of fun with valgrind and took a stab at fixing a couple memleaks from allocated but unreferenced memory. They're mostly minor in nature except for the ~64 kB crater from XKeyboard initialisation. That one is fixed by commit bf3472e where I'm a bit unsure about whether there could be side effects from using `XCloseDisplay` directly - happy to get a review!