### PR TITLE
fix uinput touchscreen handling for devices without ABS_PRESSURE

### DIFF
--- a/src/uinput.c
+++ b/src/uinput.c
@@ -789,6 +789,13 @@ static void ptr_abs(int x, int y, int p) {
 		ev.code = ABS_PRESSURE;
 		ev.value = p;
 		write(d, &ev, sizeof(ev));
+
+		if (!btn_touch) {
+			ev.type = EV_KEY;
+			ev.code = BTN_TOUCH;
+			ev.value = p ? 1 : 0;
+			write(d, &ev, sizeof(ev));
+		}
 	}
 
 	ev.type = EV_SYN;


### PR DESCRIPTION
In the past most touchscreens delivered ABS_PRESSURE and BTN_TOUCH.
Applications expected one of these two events as pen-down information.
x11vnc delivers only ABS_PRESSURE.

Some modern touchscreens do not deliver ABS_PRESSURE any more, so
x11vnc is unable to inject this event. This leads to the problem
that applications will never get pen-down.

This patch fixes this issue by injecting a BTN_TOUCH in addition to a
ABS_PRESSURE.

Signed-off-by: Martin Kepplinger <martin.kepplinger@ginzinger.com>