### PR TITLE
Misc gcc -Wall fixes

### DIFF
--- a/src/connections.c
+++ b/src/connections.c
@@ -695,7 +695,7 @@ int run_user_command(char *cmd, rfbClientPtr client, char *mode, char *input,
 
 #if LIBVNCSERVER_HAVE_FORK
 	{
-		pid_t pid, pidw;
+		pid_t pid;
 		struct sigaction sa, intr, quit;
 		sigset_t omask;
 
@@ -711,7 +711,7 @@ int run_user_command(char *cmd, rfbClientPtr client, char *mode, char *input,
 		if ((pid = fork()) > 0 || pid == -1) {
 
 			if (pid != -1) {
-				pidw = waitpid(pid, &rc, 0);
+				waitpid(pid, &rc, 0);
 			}
 
 			sigaction(SIGINT,  &intr, (struct sigaction *) NULL);

--- a/src/connections.c
+++ b/src/connections.c
@@ -2644,7 +2644,7 @@ static void reverse_connect_timeout (int sig) {
 
 static int do_reverse_connect(char *str_in) {
 	rfbClientPtr cl;
-	char *host, *p, *str = str_in, *s = NULL;
+	char *host, *p, *str = str_in;
 	char *prestring = NULL;
 	int prestring_len = 0;
 	int rport = 5500, len = strlen(str);
@@ -2673,7 +2673,6 @@ static int do_reverse_connect(char *str_in) {
 		/*   repeater=string+host:port */
 		char *plus = strrchr(str, '+');
 		str = (char *) malloc(strlen(str_in)+1);
-		s = str;
 		*plus = '\0';
 		sprintf(str, "repeater=%s+%s", plus+1, str_in + strlen("repeater://"));
 		prestring = get_repeater_string(str, &prestring_len);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1728,7 +1728,6 @@ void restore_cursor_shape_updates(rfbScreenInfoPtr s) {
 void disable_cursor_shape_updates(rfbScreenInfoPtr s) {
 	rfbClientIteratorPtr iter;
 	rfbClientPtr cl;
-	static int changed = 0;
 	int count = 0;
 
 	if (! s || ! s->clientHead) {
@@ -1765,10 +1764,6 @@ void disable_cursor_shape_updates(rfbScreenInfoPtr s) {
 		cl->cursorWasChanged = FALSE;
 	}
 	rfbReleaseClientIterator(iter);
-
-	if (count) {
-		changed = 1;
-	}
 }
 
 int cursor_shape_updates_clients(rfbScreenInfoPtr s) {

--- a/src/inet.c
+++ b/src/inet.c
@@ -696,7 +696,8 @@ int accept_unix(int s) {
 	if (s) {}
 	return -1;
 #else
-	int fd, fromlen;
+	int fd;
+	socklen_t fromlen;
 	struct sockaddr_un fsaun;
 
 	fd = accept(s, (struct sockaddr *)&fsaun, &fromlen);

--- a/src/inet.c
+++ b/src/inet.c
@@ -234,12 +234,10 @@ int get_local_port(int sock) {
 static char *get_host(int sock, int remote) {
 	struct sockaddr_in saddr;
 	unsigned int saddr_len;
-	int saddr_port;
 	char *saddr_ip_str = NULL;
 	
 	saddr_len = sizeof(saddr);
 	memset(&saddr, 0, sizeof(saddr));
-	saddr_port = -1;
 #if LIBVNCSERVER_HAVE_NETINET_IN_H
 	if (remote) {
 		if (!getpeername(sock, (struct sockaddr *)&saddr, &saddr_len)) {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -3073,7 +3073,9 @@ void keyboard(rfbBool down, rfbKeySym keysym, rfbClientPtr client) {
 	static rfbKeySym last_keysym = NoSymbol;
 	static rfbKeySym max_keyrepeat_last_keysym = NoSymbol;
 	static double max_keyrepeat_last_time = 0.0;
+#ifdef MAX_KEYREPEAT
 	static double max_keyrepeat_always = -1.0;
+#endif
         ClientData *cd = (ClientData *) client->clientData;
 
 	if (threads_drop_input) {
@@ -3231,8 +3233,6 @@ void keyboard(rfbBool down, rfbKeySym keysym, rfbClientPtr client) {
 	if (max_keyrepeat_always > 0.0) {
 		max_keyrepeat_time = max_keyrepeat_always;
 	}
-#else
-	if (0) {max_keyrepeat_always=0;}
 #endif
 	if (!down && skipped_last_down) {
 		int db = debug_scroll;

--- a/src/scan.c
+++ b/src/scan.c
@@ -2819,7 +2819,8 @@ if (db && snapcnt++ < 5) rfbLog("rawfb copy_snap took: %.5f secs\n", dnow() - st
 	return 0;
 }
 
-
+/* STFU: Only for debugging */
+#if 0
 /* 
  * debugging: print out a picture of the tiles.
  */
@@ -2861,6 +2862,7 @@ static void print_tiles(void) {
 	}
 	usleep(ms * 1000);
 }
+#endif
 
 /*
  * Utilities for managing the "naps" to cut down on amount of polling.
@@ -3358,7 +3360,6 @@ int scan_for_updates(int count_only) {
 	double frac2 = 0.35;  /* or 3rd */
 	double frac3 = 0.02;  /* do scan_display() again after copy_tiles() */
 	static double last_poll = 0.0;
-	double dtmp = 0.0;
 
 	if (unixpw_in_progress) return 0;
  
@@ -3587,24 +3588,12 @@ int scan_for_updates(int count_only) {
 
 	if (unixpw_in_progress) return 0;
 
-/* XXX Y */
-if (0 && tile_count > 20) print_tiles();
-#if 0
-dtmp = dnow();
-#else
-dtmp = 0.0;
-#endif
-
 	if (old_copy_tile) {
 		tile_diffs = copy_all_tiles();
 	} else {
 		tile_diffs = copy_all_tile_runs();
 	}
 	SCAN_FATAL(tile_diffs);
-
-#if 0
-if (tile_count) fprintf(stderr, "XX copytile: %.4f  tile_count: %d\n", dnow() - dtmp, tile_count);
-#endif
 
 	/*
 	 * This backward pass for upward and left tiles complements what

--- a/src/screen.c
+++ b/src/screen.c
@@ -2455,7 +2455,6 @@ XImage *initialize_xdisplay_fb(void) {
 	char *vis_str = visual_str;
 	int try = 0, subwin_tries = 3;
 	XErrorHandler old_handler = NULL;
-	int subwin_bs;
 
 	if (raw_fb_str) {
 		return initialize_raw_fb(0);
@@ -2571,8 +2570,6 @@ if (0) fprintf(stderr, "vis_str %s\n", vis_str ? vis_str : "notset");
 		}
 		dpy_x = wdpy_x = attr.width;
 		dpy_y = wdpy_y = attr.height;
-
-		subwin_bs = attr.backing_store;
 
 		/* this may be overridden via visual_id below */
 		default_visual = attr.visual;
@@ -2747,7 +2744,9 @@ if (0) fprintf(stderr, "DefaultDepth: %d  visial_id: %d\n", depth, (int) visual_
 		trapped_xerror = 0;
 
 	} else if (fb == NULL) {
+#if HAVE_LIBXRANDR
 		XEvent xev;
+#endif
 		rfbLog("initialize_xdisplay_fb: *** fb creation failed: 0x%x try: %d\n", fb, try);
 #if HAVE_LIBXRANDR
 		if (xrandr_present && xrandr_base_event_type) {
@@ -4033,14 +4032,12 @@ static void check_cursor_changes(void) {
 
 	if (cursor_changes) {
 		double tm, max_push = 0.125, multi_push = 0.01, wait = 0.02;
-		int cursor_shape, dopush = 0, link, latency, netrate;
+		int dopush = 0, link, latency, netrate;
 
 		if (! all_clients_initialized()) {
 			/* play it safe */
 			return;
 		}
-
-		if (0) cursor_shape = cursor_shape_updates_clients(screen);
 	
 		dtime0(&tm);
 		link = link_rate(&latency, &netrate);

--- a/src/solid.c
+++ b/src/solid.c
@@ -120,7 +120,6 @@ static char *cmd_output(char *cmd) {
 	FILE *p;
 	static char output[50000];
 	char line[1024];
-	int rc;
 
 	if (!cmd || *cmd == '\0') {
 		return "";
@@ -149,7 +148,7 @@ static char *cmd_output(char *cmd) {
 			strcat(output, line);
 		}
 	}
-	rc = pclose(p);
+	pclose(p);
 	return(output);
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -70,7 +70,7 @@ extern double rect_overlap(int x1, int y1, int x2, int y2, int X1, int Y1,
 extern char *choose_title(char *display);
 
 
-#define NONUL(x) ((x) ? (x) : "")
+#define NONUL(x) ((x != NULL) ? (x) : "")
 
 /*
 	Put this in usleep2() for debug printout.


### PR DESCRIPTION
Misc fixes for findings I detected using GCC flag -Wall and -Werror

Most of them are unused variables. Removing them from the code makes the code less complex and more maintainable.

This PR does not yet make the code fully -Wall proof. This is a first "harmless" PR.