### PR TITLE
Broken cursor bugfix for 64 bit systems

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1317,7 +1317,7 @@ static int get_exact_cursor(int init) {
 			return which;
 		}
 
-		which = store_cursor(xfc->cursor_serial, xfc->pixels,
+		which = store_cursor(xfc->cursor_serial, (uint32_t *)xfc->pixels,
 		    xfc->width, xfc->height, 32, xfc->xhot, xfc->yhot);
 
 		X_LOCK;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1008,7 +1008,7 @@ void initialize_xfixes(void) {
 rfbCursorPtr pixels2curs(uint32_t *pixels, int w, int h,
     int xhot, int yhot, int Bpp) {
 	rfbCursorPtr c;
-	static unsigned long black = 0, white = 1;
+	static uint32_t black = 0, white = 1;
 	static int first = 1;
 	char *bitmap, *rich, *alpha;
 	char *pixels_new = NULL;
@@ -1154,8 +1154,8 @@ rfbCursorPtr pixels2curs(uint32_t *pixels, int w, int h,
 	i = 0;
 	for (y = 0; y < h; y++) {
 		for (x = 0; x < w; x++) {
-			unsigned long r, g, b, a;
-			unsigned int ui;
+			uint32_t r, g, b, a;
+			uint32_t ui;
 			char *p;
 
 			a = 0xff000000 & (*(pixels+i));

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1043,48 +1043,10 @@ rfbCursorPtr pixels2curs(uint32_t *pixels, int w, int h,
 
 		pixels_new = (char *) malloc(4*w*h);
 
-		if (sizeof(unsigned long) == 8) {
-			int i, j, k = 0;
-			/*
-			 * to avoid 64bpp code in scale_rect() we knock
-			 * down to unsigned int on 64bit machines:
-			 */
-			pixels32 = (unsigned int*) malloc(4*W*H);
-			for (j=0; j<H; j++) {
-			    for (i=0; i<W; i++) {
-				*(pixels32+k) = 0xffffffff & (*(pixels+k));
-				k++;
-			    }
-			}
-			pixels_use = (char *) pixels32;
-		}
-
 		scale_rect(scale_cursor_fac_x, scale_cursor_fac_y, scaling_cursor_blend,
 		    scaling_cursor_interpolate,
 		    4, pixels_use, 4*W, pixels_new, 4*w,
 		    W, H, w, h, 0, 0, W, H, 0);
-
-		if (sizeof(unsigned long) == 8) {
-			int i, j, k = 0;
-			unsigned long *pixels64;
-			unsigned int* source = (unsigned int*) pixels_new;
-			/*
-			 * now knock it back up to unsigned long:
-			 */
-			pixels64 = (unsigned long*) malloc(8*w*h);
-			for (j=0; j<h; j++) {
-			    for (i=0; i<w; i++) {
-				*(pixels64+k) = (unsigned long) (*(source+k));
-				k++;
-			    }
-			}
-			free(pixels_new);
-			pixels_new = (char *) pixels64;
-			if (pixels32) {
-				free(pixels32);
-				pixels32 = NULL;
-			}
-		}
 			
 		pixels = (uint32_t *) pixels_new;
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -68,7 +68,7 @@ void set_no_cursor(void);
 void set_warrow_cursor(void);
 int set_cursor(int x, int y, int which);
 int check_x11_pointer(void);
-int store_cursor(int serial, unsigned long *data, int w, int h, int cbpp, int xhot, int yhot);
+int store_cursor(int serial, uint32_t *data, int w, int h, int cbpp, int xhot, int yhot);
 unsigned long get_cursor_serial(int mode);
 rfbCursorPtr pixels2curs(uint32_t *pixels, int w, int h, int xhot, int yhot, int Bpp);
 void save_under_cursor_buffer(rfbClientPtr cl);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1033,7 +1033,6 @@ rfbCursorPtr pixels2curs(uint32_t *pixels, int w, int h,
 	if (scaling_cursor && (scale_cursor_fac_x != 1.0 || scale_cursor_fac_y != 1.0)) {
 		int W, H;
 		char *pixels_use = (char *) pixels;
-		unsigned int *pixels32 = NULL;
 
 		W = w;
 		H = h;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1328,7 +1328,7 @@ static int get_exact_cursor(int init) {
 	return(which);
 }
 
-int store_cursor(int serial, unsigned long *data, int w, int h, int cbpp,
+int store_cursor(int serial, uint32_t *data, int w, int h, int cbpp,
     int xhot, int yhot) {
 	int which = CURS_ARROW;
 	int use, oldest, i;
@@ -1414,7 +1414,7 @@ fprintf(stderr, "sc: %d  %d/%d %d - %d %d\n", serial, w, h, cbpp, xhot, yhot);
 	}
 
 	/* place cursor into our collection */
-	cursors[use]->rfb = pixels2curs((uint32_t*)data, w, h, xhot, yhot, bpp/8);
+	cursors[use]->rfb = pixels2curs(data, w, h, xhot, yhot, bpp/8);
 
 	/* update time and serial index: */
 	curs_times[use] = now;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -47,7 +47,6 @@ extern int alpha_blend;
 extern int alt_arrow;
 extern int alt_arrow_max;
 
-
 extern void first_cursor(void);
 extern void setup_cursors_and_push(void);
 extern void initialize_xfixes(void);
@@ -64,7 +63,7 @@ extern void set_no_cursor(void);
 extern void set_warrow_cursor(void);
 extern int set_cursor(int x, int y, int which);
 extern int check_x11_pointer(void);
-extern int store_cursor(int serial, unsigned long *data, int w, int h, int cbpp, int xhot, int yhot);
+extern int store_cursor(int serial, uint32_t *data, int w, int h, int cbpp, int xhot, int yhot);
 extern unsigned long get_cursor_serial(int mode);
 extern rfbCursorPtr pixels2curs(uint32_t *pixels, int w, int h, int xhot, int yhot, int Bpp);
 void save_under_cursor_buffer(rfbClientPtr cl);

--- a/src/screen.c
+++ b/src/screen.c
@@ -1206,10 +1206,10 @@ void vnc_reflect_got_update(rfbClient *cl, int x, int y, int w, int h) {
 void vnc_reflect_got_cursorshape(rfbClient *cl, int xhot, int yhot, int width, int height, int bytesPerPixel) {
 	static int serial = 1;
 	int i, j;
-	char *pixels = NULL;
-	unsigned long r, g, b;
-	unsigned int ui = 0;
-	unsigned long red_mask, green_mask, blue_mask;
+	uint32_t *pixels = NULL;
+	uint32_t r, g, b;
+	uint32_t ui = 0;
+	uint32_t red_mask, green_mask, blue_mask;
 
 	if (cl) {}
 	if (unixpw_in_progress) {
@@ -1230,21 +1230,20 @@ void vnc_reflect_got_cursorshape(rfbClient *cl, int xhot, int yhot, int width, i
 	green_mask = (client->format.greenMax << client->format.greenShift);
 	blue_mask  = (client->format.blueMax  << client->format.blueShift);
 
-	pixels = (char *)malloc(4*width*height);
+	pixels = (uint32_t *)malloc(4*width*height);
 	for (j=0; j<height; j++) {
 		for (i=0; i<width; i++) {
-			unsigned int* uip;
 			unsigned char* uic;
 			int m;
 			if (bytesPerPixel == 1) {
-				unsigned char* p = (unsigned char *) client->rcSource;
-				ui = (unsigned long) *(p + j * width + i);
+				uint8_t* p = (uint8_t *) client->rcSource;
+				ui = (uint32_t) *(p + j * width + i);
 			} else if (bytesPerPixel == 2) {
-				unsigned short* p = (unsigned short *) client->rcSource;
-				ui = (unsigned long) *(p + j * width + i);
+				uint16_t* p = (uint16_t *) client->rcSource;
+				ui = (uint32_t) *(p + j * width + i);
 			} else if (bytesPerPixel == 4) {
-				unsigned int* p = (unsigned int *) client->rcSource;
-				ui = (unsigned long) *(p + j * width + i);
+				uint32_t* p = (uint32_t *) client->rcSource;
+				ui = (uint32_t) *(p + j * width + i);
 			}
 			r = (red_mask   & ui) >> client->format.redShift;
 			g = (green_mask & ui) >> client->format.greenShift;
@@ -1261,12 +1260,11 @@ void vnc_reflect_got_cursorshape(rfbClient *cl, int xhot, int yhot, int width, i
 			if (m) {
 				ui |= 0xff000000;
 			}
-			uip = (unsigned int *)pixels;
-			*(uip + j * width + i) = ui;
+			*(pixels + j * width + i) = ui;
 		}
 	}
 
-	store_cursor(serial++, (unsigned long*) pixels, width, height, 32, xhot, yhot);
+	store_cursor(serial++, pixels, width, height, 32, xhot, yhot);
 	free(pixels);
 	set_cursor(cursor_x, cursor_y, get_which_cursor());
 }


### PR DESCRIPTION
Fixes broken cursor images in 0.9.14 introduced in commit a9c95879b8822dac524c5ca6d74575f41bcf6914, reported by bug #42 

The origin of the bug is the change from 64 bit element sizes to 32 bit element sizes in pointer arithmetics without honoring the different element sizes. 
In this special case it was a fuzziness in the structure definition in 
[XFixesCursorImage](https://stackoverflow.com/questions/22891351/structure-of-xfixescursorimage).
This commit fixes the problem with a small footprint in the code and with more fixes for pixel repesentation types.

There was a more massive PR #45 before which removed features.
This one has focus on small fix footprint for easier merging and less side effects.