### PR TITLE
Fix anonymous SSL.

### DIFF
--- a/src/sslhelper.c
+++ b/src/sslhelper.c
@@ -1596,6 +1596,10 @@ static int switch_to_anon_dh(void) {
 	if (ssl_client_mode) {
 		return 1;
 	}
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	/* Security level must be set to 0 for unauthenticated suites. */
+	SSL_CTX_set_security_level(ctx, 0);
+#endif
 	if (!SSL_CTX_set_cipher_list(ctx, "ADH:@STRENGTH")) {
 		return 0;
 	}


### PR DESCRIPTION
In version 1.1.0, openssl introduced a security level concept. Only level 0
allows the use of unauthenticated cipher suites such as ADH.