### PR TITLE
Fixed Buffer Overflow Issue

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -670,7 +670,7 @@ int listen_unix(char *file) {
 		return -1;
 	}
 	saun.sun_family = AF_UNIX;
-	strncpy(saun.sun_path, file, sizeof(saun.sun_path) - 1);
+	strncpy(saun.sun_path, file, sizeof(saun.sun_path));
 	unlink(file);
 
 	len = sizeof(saun.sun_family) + strlen(saun.sun_path);

--- a/src/inet.c
+++ b/src/inet.c
@@ -670,7 +670,7 @@ int listen_unix(char *file) {
 		return -1;
 	}
 	saun.sun_family = AF_UNIX;
-	snprintf(saun.sun_path, sizeof(saun.sun_path), "%s", file);
+	strncpy(saun.sun_path, file, sizeof(saun.sun_path) - 1);
 	unlink(file);
 
 	len = sizeof(saun.sun_family) + strlen(saun.sun_path);

--- a/src/inet.c
+++ b/src/inet.c
@@ -670,7 +670,7 @@ int listen_unix(char *file) {
 		return -1;
 	}
 	saun.sun_family = AF_UNIX;
-	strcpy(saun.sun_path, file);
+	snprintf(saun.sun_path, sizeof(saun.sun_path), "%s", file);
 	unlink(file);
 
 	len = sizeof(saun.sun_family) + strlen(saun.sun_path);


### PR DESCRIPTION
Hi,

## Description
```
less /usr/include/linux/un.h
```
```bash
/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
#ifndef _LINUX_UN_H
#define _LINUX_UN_H

#include <linux/socket.h>

#define UNIX_PATH_MAX   108

struct sockaddr_un {
        __kernel_sa_family_t sun_family; /* AF_UNIX */
        char sun_path[UNIX_PATH_MAX];   /* pathname */
};

#define SIOCUNIXFILE (SIOCPROTOPRIVATE + 0) /* open a socket file with O_PATH */

#endif /* _LINUX_UN_H */
```

We see char sun_path[UNIX_PATH_MAX]; /* pathname */ of sockaddr_un that UNIX_PATH_MAX=108

## Overflow code

`strcpy(saun.sun_path, file);`

There isn't any check if length file greater of length saun.sun_path

Thanks,
Ramin - Saminray Security Researcher Team (SSRT)