### PR TITLE
Support 7 mouse buttons

### DIFF
--- a/src/params.h
+++ b/src/params.h
@@ -75,7 +75,7 @@ so, delete this exception statement from your version.
 #define PIPEINPUT_MACOSX	0x4
 #define PIPEINPUT_VNC		0x5
 
-#define MAX_BUTTONS 5
+#define MAX_BUTTONS 7
 
 #define ROTATE_NONE		0
 #define ROTATE_X		1


### PR DESCRIPTION
The VNC protocol supports buttons up to 7 different ones, the button
6-7 is for horizontal scrolling.  Tested this change with both
tigervnc and tightvnc as client.