### PR TITLE
src/cursor: fix xfc NULL pointer dereference

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1311,7 +1311,7 @@ static int get_exact_cursor(int init) {
 
 		/* retrieve the cursor info + pixels from server: */
 		xfc = XFixesGetCursorImage(dpy);
-		{
+		if (xfc) {
 			/* 2017-07-09, Stephan Fuhrmann: This fixes an implementation flaw for 64 bit systems.
 			 * The XFixesCursorImage structure says xfc->pixels is (unsigned long*) in the structure, but
 			 * the protocol spec says it's 32 bit per pixel


### PR DESCRIPTION
xfc->width and xfc->height for the XFixes cursor image returned from
XFixesGetCursorImage(dpy) are accessed without first checking that xfc
is not NULL. This can result in the server sometimes crashing when
moving a Google Chrome window.

Fixes: 37c946191a0f ("Broken cursor bugfix for 64 bit systems (#49)")
Signed-off-by: Jonathan Liu <net147@gmail.com>