### PR TITLE
src/sslhelper: fix tls handshake failed error w/ OpenSSL 1.1.x

### DIFF
--- a/src/sslhelper.c
+++ b/src/sslhelper.c
@@ -1600,7 +1600,7 @@ static int switch_to_anon_dh(void) {
 	/* Security level must be set to 0 for unauthenticated suites. */
 	SSL_CTX_set_security_level(ctx, 0);
 #endif
-	if (!SSL_CTX_set_cipher_list(ctx, "ADH:@STRENGTH")) {
+	if (!SSL_CTX_set_cipher_list(ctx, "ADH:@SECLEVEL=0")) {
 		return 0;
 	}
 	if (!add_anon_dh()) {


### PR DESCRIPTION
x11vnc server uses ADH based ciphersuites which are not available
in the default security level in OpenSSL 1.1.1, causes tls handshake
failed error.

lowered the ADH security level from"ADH:@STRENGTH to ADH:@SECLEVEL=0

This fixes : TLS Handshake failed error w/ OpenSSL 1.1.x #129