### PR TITLE
screen: add variables initializations

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -1943,7 +1943,7 @@ if (db) fprintf(stderr, "initialize_raw_fb reset\n");
 
 
 	/* +O offset */
-	char *end;
+	char *end = NULL;
 	if ((q = strrchr(str, '+')) != NULL) {
 		end = q;
 		if (sscanf(q, "+%d", &raw_fb_offset) != 1) {
@@ -2150,7 +2150,7 @@ if (db) fprintf(stderr, "initialize_raw_fb reset\n");
 	} else if (strstr(str, "map:") == str || strstr(str, "mmap:") == str
 	    || strstr(str, "file:") == str) {
 		/* map:/path/... or file:/path  */
-		int fd, do_mmap = 1, size, vsize;
+		int fd, do_mmap = 1, size, vsize = 0;
 		struct stat sbuf;
 
 		if (*str == 'f') {


### PR DESCRIPTION
This fixes the following warnings:

src/screen.c: In function 'initialize_raw_fb':

src/screen.c:2248:6: error: 'vsize' may be used uninitialized in this function [-Werror=maybe-uninitialized]

      rfbLog("   w: %d h: %d b: %d addr: %p sz: %d\n", w, h,

      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

       b, raw_fb_addr, vsize);

       ~~~~~~~~~~~~~~~~~~~~~~

src/screen.c:1946:8: error: 'end' may be used uninitialized in this function [-Werror=maybe-uninitialized]

  char *end;

        ^~~