### PR TITLE
use a clearer error message clearer when your password is too long

### DIFF
--- a/src/x11vnc.c
+++ b/src/x11vnc.c
@@ -1745,10 +1745,17 @@ static void check_appshare_mode(int argc, char* argv[]) {
 
 static void store_homedir_passwd(char *file) {
 	char str1[32], str2[32], *p, *h, *f;
+	int newlines, maxlen;
 	struct stat sbuf;
 
 	str1[0] = '\0';
 	str2[0] = '\0';
+	/* fgets() stops at and includes the newline */
+	/* unless the input limit was reached, then it stops at the limit */
+	/* and does _not_ include the newline. trailing null is always set. */
+	newlines = 0;
+	/* maxlen excludes trailing null and newline from input */
+	maxlen = (sizeof(str1)/sizeof(char)) - 2;
 
 	/* storepasswd */
 	if (no_external_cmds || !cmd_ok("storepasswd")) {
@@ -1775,10 +1782,17 @@ static void store_homedir_passwd(char *file) {
 	system("stty echo");
 
 	if ((p = strchr(str1, '\n')) != NULL) {
+		++newlines;
 		*p = '\0';
 	}
 	if ((p = strchr(str2, '\n')) != NULL) {
+		++newlines;
 		*p = '\0';
+	}
+	if (2 != newlines) {
+		/* this is just for a clearer error message. strcmp() will also fail */
+		fprintf(stderr, "** password exceeds maximum %d bytes.\n", maxlen);
+		exit(1);
 	}
 	if (strcmp(str1, str2)) {
 		fprintf(stderr, "** passwords differ.\n");

--- a/src/x11vnc.c
+++ b/src/x11vnc.c
@@ -1745,18 +1745,10 @@ static void check_appshare_mode(int argc, char* argv[]) {
 
 static void store_homedir_passwd(char *file) {
 	char str1[32], str2[32], *p, *h, *f;
-	int newlines, maxlen;
 	struct stat sbuf;
 
 	str1[0] = '\0';
 	str2[0] = '\0';
-	/* fgets() stops at and includes the newline */
-	/* unless the input limit was reached, then it stops at the limit */
-	/* and does _not_ include the newline. trailing null is always set. */
-	newlines = 0;
-	/* maxlen excludes trailing null and newline from input */
-	maxlen = (sizeof(str1)/sizeof(char)) - 2;
-
 	/* storepasswd */
 	if (no_external_cmds || !cmd_ok("storepasswd")) {
 		fprintf(stderr, "-nocmds cannot be used with -storepasswd\n");
@@ -1782,16 +1774,15 @@ static void store_homedir_passwd(char *file) {
 	system("stty echo");
 
 	if ((p = strchr(str1, '\n')) != NULL) {
-		++newlines;
 		*p = '\0';
 	}
 	if ((p = strchr(str2, '\n')) != NULL) {
-		++newlines;
 		*p = '\0';
 	}
-	if (2 != newlines) {
-		/* this is just for a clearer error message. strcmp() will also fail */
-		fprintf(stderr, "** password exceeds maximum %d bytes.\n", maxlen);
+	if (8 < strlen(str1)) {
+		/* RFC6143 states: "the password is truncated to eight characters" */
+		/* there's room for ambiguity (characters vs bytes) */
+		fprintf(stderr, "** password exceeds maximum 8 bytes.\n");
 		exit(1);
 	}
 	if (strcmp(str1, str2)) {


### PR DESCRIPTION
Consider the password '12345678901234567890123456789012' which is 32 bytes.

Prior to this commit, you could use `x11vnc -storepasswd file` and you would
see a prompt to enter that password. When you type it in and press enter,
the prompt would turn into:
```
Enter VNC password:
Verify password:
** passwords differ.
```

The reason is related to the length of the buffer and `fgets()` is kinda
broken. It doesn't tell you that there's too many characters. But it does
leave the newline from pressing enter on input. So that gets checked for,
and if it's not there then it's assumed the password was too long.

The new output is:
```
Enter VNC password:
Verify password:
** password exceeds maximum 30 characters.
```

This makes it clearer to the user how to solve the problem.