### PR TITLE
Fix video4linux headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ AH_TEMPLATE(HAVE_SOLARIS_XREADSCREEN, [Solaris XReadScreen available])
 AH_TEMPLATE(HAVE_IRIX_XREADDISPLAY, [IRIX XReadDisplay available])
 AH_TEMPLATE(HAVE_FBPM, [FBPM extension build environment present])
 AH_TEMPLATE(HAVE_DPMS, [DPMS extension build environment present])
+AH_TEMPLATE(HAVE_LIBV4L1_VIDEODEV_H, [libv4l build environment present])
 AH_TEMPLATE(HAVE_LINUX_VIDEODEV_H, [video4linux build environment present])
 AH_TEMPLATE(HAVE_LINUX_FB_H, [linux fb device build environment present])
 AH_TEMPLATE(HAVE_LINUX_INPUT_H, [linux/input.h present])
@@ -333,6 +334,8 @@ configure again.
 fi
 
 if test "x$with_v4l" != "xno"; then
+	AC_CHECK_HEADER(libv4l1-videodev.h,
+		[AC_DEFINE(HAVE_LIBV4L1_VIDEODEV_H)],,)
 	AC_CHECK_HEADER(linux/videodev.h,
 		[AC_DEFINE(HAVE_LINUX_VIDEODEV_H)],,)
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ AH_TEMPLATE(HAVE_FBPM, [FBPM extension build environment present])
 AH_TEMPLATE(HAVE_DPMS, [DPMS extension build environment present])
 AH_TEMPLATE(HAVE_LIBV4L1_VIDEODEV_H, [libv4l build environment present])
 AH_TEMPLATE(HAVE_LINUX_VIDEODEV_H, [video4linux build environment present])
+AH_TEMPLATE(HAVE_LINUX_VIDEODEV2_H, [video4linux2 build environment present])
 AH_TEMPLATE(HAVE_LINUX_FB_H, [linux fb device build environment present])
 AH_TEMPLATE(HAVE_LINUX_INPUT_H, [linux/input.h present])
 AH_TEMPLATE(HAVE_LINUX_UINPUT_H, [linux uinput device build environment present])
@@ -338,6 +339,8 @@ if test "x$with_v4l" != "xno"; then
 		[AC_DEFINE(HAVE_LIBV4L1_VIDEODEV_H)],,)
 	AC_CHECK_HEADER(linux/videodev.h,
 		[AC_DEFINE(HAVE_LINUX_VIDEODEV_H)],,)
+	AC_CHECK_HEADER(linux/videodev2.h,
+		[AC_DEFINE(HAVE_LINUX_VIDEODEV2_H)],,)
 fi
 if test "x$with_fbdev" != "xno"; then
 	AC_CHECK_HEADER(linux/fb.h,

--- a/src/v4l.c
+++ b/src/v4l.c
@@ -47,6 +47,9 @@ so, delete this exception statement from your version.
 #define CONFIG_VIDEO_V4L1_COMPAT
 #if HAVE_LIBV4L1_VIDEODEV_H
 #include <libv4l1-videodev.h>
+#if HAVE_LINUX_VIDEODEV2_H
+#include <linux/videodev2.h>
+#endif
 #else
 #include <linux/videodev.h>
 #endif

--- a/src/v4l.c
+++ b/src/v4l.c
@@ -41,11 +41,15 @@ so, delete this exception statement from your version.
 #include "keyboard.h"
 #include "allowed_input_t.h"
 
-#if HAVE_LINUX_VIDEODEV_H
+#if HAVE_LIBV4L1_VIDEODEV_H || HAVE_LINUX_VIDEODEV_H
 #if HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #define CONFIG_VIDEO_V4L1_COMPAT
+#if HAVE_LIBV4L1_VIDEODEV_H
+#include <libv4l1-videodev.h>
+#else
 #include <linux/videodev.h>
+#endif
 #ifdef __LINUX_VIDEODEV2_H
 # ifndef HAVE_V4L2
 # define HAVE_V4L2 1


### PR DESCRIPTION
The `linux/videodev.h` header was removed in kernel 2.6.38.  A drop-in replacement header is available from libv4l as `libv4l1-videodev.h`: use that if available.

Unlike the original `linux/videodev.h` header, the replacement `libv4l1-videodev.h` header does not automatically include `linux/videodev2.h`: include `linux/videodev2.h` explicitly as needed.
