### PR TITLE
display cursor in correct position when using `-rotate` and moving cursor on host

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1833,6 +1833,8 @@ void cursor_position(int x, int y, rfbClientPtr client) {
 		if (y >= dpy_y) y = dpy_y-1;
 	}
 
+	if (rotating)
+	    rotate_cursor_coords(x, y, &x, &y, screen->width, screen->height);
 
 	if(client == NULL) {
 	/* handle screen's master cursor */
@@ -2103,16 +2105,11 @@ if (0) fprintf(stderr, "check_x11_pointer %d %d\n", root_x, root_y);
 		}
 	}
 
-	int x_rotated = x, y_rotated = y;
-	if (screen) {
-		rotate_cursor_coords(x, y, &x_rotated, &y_rotated, screen->width, screen->height);
-	}
-
 	/* record the cursor position in the rfb screen */
-	cursor_position(x_rotated, y_rotated, NULL);
+	cursor_position(x, y, NULL);
 
 	/* change the cursor shape if necessary */
-	rint = set_cursor(x_rotated, y_rotated, get_which_cursor());
+	rint = set_cursor(x, y, get_which_cursor());
 	return rint;
 }
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -2103,11 +2103,16 @@ if (0) fprintf(stderr, "check_x11_pointer %d %d\n", root_x, root_y);
 		}
 	}
 
+	int x_rotated = x, y_rotated = y;
+	if (screen) {
+		rotate_cursor_coords(x, y, &x_rotated, &y_rotated, screen->width, screen->height);
+	}
+
 	/* record the cursor position in the rfb screen */
-	cursor_position(x, y, NULL);
+	cursor_position(x_rotated, y_rotated, NULL);
 
 	/* change the cursor shape if necessary */
-	rint = set_cursor(x, y, get_which_cursor());
+	rint = set_cursor(x_rotated, y_rotated, get_which_cursor());
 	return rint;
 }
 

--- a/src/scan.c
+++ b/src/scan.c
@@ -1386,6 +1386,11 @@ void rotate_coords(int x, int y, int *xo, int *yo, int dxi, int dyi) {
 	}
 }
 
+
+/* 
+ rotate cursor coordinates for `rotating` rotation. assumes that dxi and dyi are **not** rotated.
+ separate from rotate_coords because it returns incorrect coords for 90, 90y & 270 deg rotations.
+*/
 void rotate_cursor_coords(int x, int y, int *xo, int *yo, int dxi, int dyi) {
 	int xi = x, yi = y;
 

--- a/src/scan.c
+++ b/src/scan.c
@@ -69,6 +69,7 @@ int scan_for_updates(int count_only);
 void rotate_curs(char *dst_0, char *src_0, int Dx, int Dy, int Bpp);
 void rotate_coords(int x, int y, int *xo, int *yo, int dxi, int dyi);
 void rotate_coords_inverse(int x, int y, int *xo, int *yo, int dxi, int dyi);
+void rotate_cursor_coords(int x, int y, int *xo, int *yo, int dxi, int dyi);
 
 static void set_fs_factor(int max);
 static char *flip_ximage_byte_order(XImage *xim);
@@ -1382,6 +1383,36 @@ void rotate_coords(int x, int y, int *xo, int *yo, int dxi, int dyi) {
 	} else if (rotating == ROTATE_270) {
 		*xo = yi;
 		*yo = Dx - xi - 1;
+	}
+}
+
+void rotate_cursor_coords(int x, int y, int *xo, int *yo, int dxi, int dyi) {
+	int xi = x, yi = y;
+
+	if (rotating == ROTATE_NONE) {
+		*xo = xi;
+		*yo = yi;
+	} else if (rotating == ROTATE_X) {
+		*xo = dxi - xi;
+		*yo = yi;
+	} else if (rotating == ROTATE_Y) {
+		*xo = xi;
+		*yo = dyi - yi;
+	} else if (rotating == ROTATE_XY) {
+		*xo = dxi - xi;
+		*yo = dyi - yi;
+	} else if (rotating == ROTATE_90) {
+		*xo = dxi - yi;
+		*yo = xi;
+	} else if (rotating == ROTATE_90X) {
+		*xo = yi;
+		*yo = xi;
+	} else if (rotating == ROTATE_90Y) {
+		*xo = dxi - yi;
+		*yo = dyi - xi;
+	} else if (rotating == ROTATE_270) {
+		*xo = yi;
+		*yo = dyi - xi;
 	}
 }
 

--- a/src/scan.h
+++ b/src/scan.h
@@ -56,5 +56,6 @@ extern int scan_for_updates(int count_only);
 extern void rotate_curs(char *dst_0, char *src_0, int Dx, int Dy, int Bpp);
 extern void rotate_coords(int x, int y, int *xo, int *yo, int dxi, int dyi);
 extern void rotate_coords_inverse(int x, int y, int *xo, int *yo, int dxi, int dyi);
+extern void rotate_cursor_coords(int x, int y, int *xo, int *yo, int dxi, int dyi);
 
 #endif /* _X11VNC_SCAN_H */


### PR DESCRIPTION
I couldn't find any directions about contributions to this project, let me know if there is something I should do before contributing or if there is any extra information I should provide - I'm happy to do so!

---
This fixes https://github.com/LibVNC/x11vnc/issues/152

It was as simple as this - the cursor position was not being rotated.
I've tested all rotations - `x, y, xy, 90, 270, 90y, 90x` on x11 and they draw the cursor properly after the changes. 

Sadly, I do not have access to a mac PC to test this on - help would be appreciated with that.