### PR TITLE
Allows for xinput mouse w/ pipeinput uinput kb. Closes #194

### DIFF
--- a/src/pointer.c
+++ b/src/pointer.c
@@ -630,7 +630,9 @@ static void pipe_pointer(int mask, int x, int y, rfbClientPtr client) {
 	} else if (pipeinput_int == PIPEINPUT_CONSOLE) {
 		console_pointer_command(mask, x, y, client);
 	} else if (pipeinput_int == PIPEINPUT_UINPUT) {
-		uinput_pointer_command(mask, x, y, client);
+		// uinput_pointer_command(mask, x, y, client);
+		update_x11_pointer_position(x, y, client);
+		update_x11_pointer_mask(mask, client);
 	} else if (pipeinput_int == PIPEINPUT_MACOSX) {
 		macosx_pointer_command(mask, x, y, client);
 	} else if (pipeinput_int == PIPEINPUT_VNC) {


### PR DESCRIPTION
Not ready for merging just yet as this needs to be a parameterized option for the user to decide if they want complete pipeinput for all devices or pipeinput for some except for the mouse and scrolling, which can be pushed over to x11.