### PR TITLE
Support LibreSSL

### DIFF
--- a/src/sslhelper.c
+++ b/src/sslhelper.c
@@ -1596,7 +1596,7 @@ static int switch_to_anon_dh(void) {
 	if (ssl_client_mode) {
 		return 1;
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	/* Security level must be set to 0 for unauthenticated suites. */
 	SSL_CTX_set_security_level(ctx, 0);
 #endif


### PR DESCRIPTION
When building x11vnc with LibreSSL the build fails with undefined references for SSL_CTX_set_security_level which is currently only available with OpenSSL. This can be fixed by disabling the code as is already done for OpenSSL versions older than 1.1.0.

This builds with LibreSSL 3.5.x.