### PR TITLE
Support 8th mouse button

### DIFF
--- a/src/params.h
+++ b/src/params.h
@@ -75,7 +75,7 @@ so, delete this exception statement from your version.
 #define PIPEINPUT_MACOSX	0x4
 #define PIPEINPUT_VNC		0x5
 
-#define MAX_BUTTONS 7
+#define MAX_BUTTONS 8
 
 #define ROTATE_NONE		0
 #define ROTATE_X		1


### PR DESCRIPTION
The VNC protocol supports buttons up to 8 different ones. Tested this change with [a similarly patched KRDC](https://invent.kde.org/network/krdc/-/merge_requests/44) as client.
