### PR TITLE
connections: fix snprintf null destination pointer

### DIFF
--- a/src/connections.c
+++ b/src/connections.c
@@ -2574,7 +2574,7 @@ char *get_repeater_string(char *str, int *len) {
 		if (pren > 0 && pren <= 16384) {
 			prestring_len = pren;
 			ptmp = (char *) calloc(prestring_len+1, 1);
-			snprintf(prestring, prestring_len, "%s", equals+1);
+			snprintf(ptmp, prestring_len, "%s", equals+1);
 			which = 3;
 		}
 	}


### PR DESCRIPTION
Since `prestring` is initialized with `NULL` we must not write to it before it points to allocated memory (line 2584).