### PR TITLE
Fix incorrect return type when building without X11

### DIFF
--- a/src/xwrappers.c
+++ b/src/xwrappers.c
@@ -1387,7 +1387,7 @@ Bool XInputQueryVersion_wr(Display *dpy, int *maj, int *min) {
 #if NO_X11
 	rfbLog("This x11vnc was built without X11 support (-rawfb only).\n");
 	if (!dpy || !maj || !min) {}
-	return NULL;
+	return False;
 #else
 	int ignore;
 	if(! XQueryExtension (dpy, "XInputExtension", &ignore, &ignore, &ignore))


### PR DESCRIPTION
The XInputQueryVersion_wr function when building without X11 was returning NULL which is of type void * when the function has a return type of int.