### PR TITLE
configure: drop AC_FUNC_STAT macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -496,7 +496,6 @@ if test $inaddrt = no ; then
 fi
 # Checks for library functions.
 AC_FUNC_MEMCMP
-AC_FUNC_STAT
 AC_FUNC_STRFTIME
 AC_FUNC_VPRINTF
 AC_FUNC_FORK


### PR DESCRIPTION
This macro is obsolescent and doesn't work with
-Werror=implicit-function-declaration compiler flag