### PR TITLE
Simplify the redundant conditional checks.

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -1370,7 +1370,7 @@ xkbmodifiers[]    For the KeySym bound to this (keycode,group,level) store
 					kc1_control = kc;
 				}
 			}
-			if (ks == XK_Caps_Lock || ks == XK_Caps_Lock) {
+			if (ks == XK_Caps_Lock) {
 				if (kc1_caplock == -1) {
 					kc1_caplock = kc;
 				}


### PR DESCRIPTION
It seems unnecessary to check whether ks is XK_Caps_Lock twice in the if statement. It would be fine to change it to once.